### PR TITLE
Replace two arguments builder methods with just vararg

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorBuilder.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorBuilder.kt
@@ -50,16 +50,15 @@ class LanguageDetectorBuilder private constructor(
         }
 
         @JvmStatic
-        fun fromLanguages(language: Language, vararg languages: Language): LanguageDetectorBuilder {
-            require(languages.isNotEmpty()) { MISSING_LANGUAGE_MESSAGE }
-            return LanguageDetectorBuilder(listOf(language, *languages))
+        fun fromLanguages(vararg languages: Language): LanguageDetectorBuilder {
+            require(languages.size >= 2) { MISSING_LANGUAGE_MESSAGE }
+            return LanguageDetectorBuilder(languages.toList())
         }
 
         @JvmStatic
-        fun fromIsoCodes(isoCode: String, vararg isoCodes: String): LanguageDetectorBuilder {
-            require(isoCodes.isNotEmpty()) { MISSING_LANGUAGE_MESSAGE }
-            val languages = mutableListOf(Language.getByIsoCode(isoCode))
-            languages.addAll(isoCodes.map { Language.getByIsoCode(it) })
+        fun fromIsoCodes(vararg isoCodes: String): LanguageDetectorBuilder {
+            require(isoCodes.size >= 2) { MISSING_LANGUAGE_MESSAGE }
+            val languages = isoCodes.map { Language.getByIsoCode(it) }
             return LanguageDetectorBuilder(languages)
         }
 


### PR DESCRIPTION
I have found that using `LanguageDetectorBuilder` is really inconvenient. 

For instance in our production code we call: 
`.fromIsoCodes(languages[0], *languages.drop(1).toTypedArray())`

I understand that API is designed to ensure at least two languages are provided, but sometimes it requires hacks like in the line above.

It would be great if we could simplify this :)

Please note that this is not api breaking change, all the previous method calls will behave the same.