### PR TITLE
Fixed computing language confidence values when no probability is computed

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -166,7 +166,7 @@ class LanguageDetector internal constructor(
         }
 
         val summedUpProbabilities = sumUpProbabilities(allProbabilities, unigramCountsOfInputText, languagesSequence)
-        val highestProbability = summedUpProbabilities.maxBy { it.value }!!.value
+        val highestProbability = summedUpProbabilities.maxBy { it.value }?.value ?: return sortedMapOf()
         val confidenceValues = summedUpProbabilities.mapValues { highestProbability / it.value }
 
         return confidenceValues.toSortedMap(compareByDescending { confidenceValues[it] })

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -794,6 +794,13 @@ class LanguageDetectorTest {
         )
     }
 
+    @Test
+    fun `assert that empty language confidence values are returned when unknown`() {
+        assertThat(
+            detectorForEnglishAndGerman.computeLanguageConfidenceValues("проарплап")
+        ).isEmpty()
+    }
+
     private fun defineBehaviorOfUnigramLanguageModels() {
         with(unigramLanguageModelForEnglish) {
             every { getRelativeFrequency(Ngram("a")) } returns 0.01


### PR DESCRIPTION
Fixing a NullPointerException. Maybe there's a more in-depth problem, but from my perception this seems like the most realistic solution.

I'm also not sure to which branch this should be merged, as this is more a hotfix, which should go into master and 1.1.0.