### PR TITLE
Fix word splitting algorithm for languages supporting logograms

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -276,7 +276,6 @@ class LanguageDetector internal constructor(
                 } else {
                     totalLanguageCounts.incrementCounter(JAPANESE, 1)
                 }
-
             } else {
                 val sortedWordLanguageCounts = wordLanguageCounts.toList().sortedByDescending { it.second }
                 val (mostFrequentLanguage, firstCharCount) = sortedWordLanguageCounts[0]

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -60,6 +60,7 @@ import com.github.pemistahl.lingua.api.Language.UNKNOWN
 import com.github.pemistahl.lingua.api.Language.VIETNAMESE
 import com.github.pemistahl.lingua.api.Language.YORUBA
 import com.github.pemistahl.lingua.internal.Alphabet
+import com.github.pemistahl.lingua.internal.Constant
 import com.github.pemistahl.lingua.internal.Constant.MULTIPLE_WHITESPACE
 import com.github.pemistahl.lingua.internal.Constant.NUMBERS
 import com.github.pemistahl.lingua.internal.Constant.PUNCTUATION

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -69,7 +69,8 @@ import com.github.pemistahl.lingua.internal.TestDataLanguageModel
 import com.github.pemistahl.lingua.internal.TrainingDataLanguageModel
 import com.github.pemistahl.lingua.internal.util.extension.containsAnyOf
 import com.github.pemistahl.lingua.internal.util.extension.incrementCounter
-import java.util.*
+import java.util.SortedMap
+import java.util.TreeMap
 import java.util.regex.PatternSyntaxException
 import kotlin.math.ln
 
@@ -260,7 +261,7 @@ class LanguageDetector internal constructor(
             } else if (wordLanguageCounts.size == 1) {
                 val language = wordLanguageCounts.toList().first().first
                 if (language in languages) {
-                    val logogramWordSizeOptional = logogramWordCountIfExist(language, word);
+                    val logogramWordSizeOptional = logogramWordCountIfExist(language, word)
                     if (logogramWordSizeOptional > 0) {
                         totalLanguageCounts.incrementCounter(language, logogramWordSizeOptional)
                     } else {
@@ -270,7 +271,7 @@ class LanguageDetector internal constructor(
                     totalLanguageCounts.incrementCounter(UNKNOWN, 1)
                 }
             } else if (wordLanguageCounts.containsKey(CHINESE) && wordLanguageCounts.containsKey(JAPANESE)) {
-                val logogramWordSizeOptional = logogramWordCountIfExist(JAPANESE, word);
+                val logogramWordSizeOptional = logogramWordCountIfExist(JAPANESE, word)
                 if (logogramWordSizeOptional > 0) {
                     totalLanguageCounts.incrementCounter(JAPANESE, logogramWordSizeOptional)
                 } else {
@@ -429,33 +430,32 @@ class LanguageDetector internal constructor(
 
     override fun hashCode() = 31 * languages.hashCode() + minimumRelativeDistance.hashCode()
 
-
     internal fun logogramWordCountIfExist(language: Language, word: String): Int {
-        var wordSize = 0;
+        var wordSize = 0
         if (!Constant.LANGUAGES_SUPPORTING_LOGOGRAMS.contains(language)) {
-            return wordSize;
+            return wordSize
         }
-        var otherWordSize = 0;
-        var preOtherWordSize = 0;
+        var otherWordSize = 0
+        var preOtherWordSize = 0
         for (character in word.map { it.toString() }) {
             when {
                 language.alphabets.stream().allMatch { e -> e.matches(character) } -> {
-                    wordSize += 1;
+                    wordSize += 1
                     if (preOtherWordSize != otherWordSize) {
-                        preOtherWordSize = otherWordSize;
-                        wordSize += 1;
+                        preOtherWordSize = otherWordSize
+                        wordSize += 1
                     }
                 }
                 language.alphabets.stream().noneMatch { e -> e.matches(character) } -> {
-                    preOtherWordSize = otherWordSize;
+                    preOtherWordSize = otherWordSize
                     otherWordSize += 1
                 }
             }
         }
         if (preOtherWordSize != otherWordSize) {
-            wordSize += 1;
+            wordSize += 1
         }
-        return wordSize;
+        return wordSize
     }
 
     internal companion object {

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -259,8 +259,9 @@ class LanguageDetector internal constructor(
                 totalLanguageCounts.incrementCounter(UNKNOWN)
             } else if (wordLanguageCounts.size == 1) {
                 val language = wordLanguageCounts.toList().first().first
+                var wordSize = if (language in Constant.LANGUAGES_SPLIT_BY_NO_SPACE) wordLanguageCounts[language] else 1
                 if (language in languages) {
-                    totalLanguageCounts.incrementCounter(language)
+                    wordSize?.let { totalLanguageCounts.incrementCounter(language, it) }
                 } else {
                     totalLanguageCounts.incrementCounter(UNKNOWN)
                 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -15,7 +15,8 @@
  */
 
 package com.github.pemistahl.lingua.internal
-import com.github.pemistahl.lingua.api.Language.*
+
+import com.github.pemistahl.lingua.api.Language
 
 internal object Constant {
 
@@ -26,5 +27,5 @@ internal object Constant {
     /**
      * To define the languages  word split by NO SPACE , just like CHINESE, JAPANESE, KOREAN and so on.
      */
-    val LANGUAGES_SPLIT_BY_NO_SPACE = listOf(CHINESE, JAPANESE, KOREAN)
+    val LANGUAGES_SPLIT_BY_NO_SPACE = listOf(Language.CHINESE, Language.JAPANESE, Language.KOREAN)
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -15,6 +15,7 @@
  */
 
 package com.github.pemistahl.lingua.internal
+import com.github.pemistahl.lingua.api.Language.*
 
 internal object Constant {
 

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -21,4 +21,9 @@ internal object Constant {
     val PUNCTUATION = Regex("\\p{P}")
     val NUMBERS = Regex("\\p{N}")
     val MULTIPLE_WHITESPACE = Regex("\\s+")
+
+    /**
+     * To define the languages  word split by NO SPACE , just like CHINESE, JAPANESE, KOREAN and so on.
+     */
+    val LANGUAGES_SPLIT_BY_NO_SPACE = listOf(CHINESE, JAPANESE, KOREAN)
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -23,9 +23,5 @@ internal object Constant {
     val PUNCTUATION = Regex("\\p{P}")
     val NUMBERS = Regex("\\p{N}")
     val MULTIPLE_WHITESPACE = Regex("\\s+")
-
-    /**
-     * To define the languages  word split by NO SPACE , just like CHINESE, JAPANESE, KOREAN and so on.
-     */
-    val LANGUAGES_SPLIT_BY_NO_SPACE = listOf(Language.CHINESE, Language.JAPANESE, Language.KOREAN)
+    val LANGUAGES_SUPPORTING_LOGOGRAMS = listOf(Language.CHINESE, Language.JAPANESE, Language.KOREAN)
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModel.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModel.kt
@@ -115,7 +115,7 @@ internal data class TrainingDataLanguageModel(
                     val textSlice = lowerCasedLine.slice(i until i + ngramLength)
                     if (regex.matches(textSlice)) {
                         val ngram = Ngram(textSlice)
-                        absoluteFrequencies.incrementCounter(ngram)
+                        absoluteFrequencies.incrementCounter(ngram, 1)
                     }
                 }
             }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
@@ -16,9 +16,6 @@
 
 package com.github.pemistahl.lingua.internal.util.extension
 
-internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) {
-    this[key] = this.getOrDefault(key, 0) + 1
-}
-internal fun <T> MutableMap<T, Int>.incrementCounter(key: T, wordSize: Int) {
-    this[key] = this.getOrDefault(key, 0) + wordSize
+internal fun <T> MutableMap<T, Int>.incrementCounter(key: T, amount: Int) {
+    this[key] = this.getOrDefault(key, 0) + amount
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
@@ -19,6 +19,6 @@ package com.github.pemistahl.lingua.internal.util.extension
 internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) {
     this[key] = this.getOrDefault(key, 0) + 1
 }
-internal fun <T> MutableMap<T, Int>.incrementCounter(key: T,wordSize:Int) {
+internal fun <T> MutableMap<T, Int>.incrementCounter(key: T, wordSize: Int) {
     this[key] = this.getOrDefault(key, 0) + wordSize
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
@@ -19,3 +19,6 @@ package com.github.pemistahl.lingua.internal.util.extension
 internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) {
     this[key] = this.getOrDefault(key, 0) + 1
 }
+internal fun <T> MutableMap<T, Int>.incrementCounter(key: T,wordSize:Int) {
+    this[key] = this.getOrDefault(key, 0) + wordSize
+}

--- a/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
+++ b/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.github.pemistahl.lingua.api.Language.ENGLISH;
 import static com.github.pemistahl.lingua.api.Language.FRENCH;
-import static com.github.pemistahl.lingua.api.Language.GERMAN;
+import static com.github.pemistahl.lingua.api.Language.CHINESE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LanguageDetectorBuilderJavaTest {

--- a/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
+++ b/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
@@ -27,7 +27,7 @@ public class LanguageDetectorBuilderJavaTest {
 
     @Test
     public void assertThatLinguaCanBeUsedWithJava() {
-        final LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(GERMAN, ENGLISH, FRENCH).build();
-        assertThat(detector.detectLanguageOf("groß")).isEqualTo(GERMAN);
+        final LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(CHINESE, ENGLISH, FRENCH).build();
+        assertThat(detector.detectLanguageOf("上海大学是一个好大学 this is a test.")).isEqualTo(ENGLISH);
     }
 }

--- a/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
+++ b/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
@@ -28,6 +28,6 @@ public class LanguageDetectorBuilderJavaTest {
     @Test
     public void assertThatLinguaCanBeUsedWithJava() {
         final LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(CHINESE, ENGLISH, FRENCH).build();
-        assertThat(detector.detectLanguageOf("上海大学是一个好大学 this is a test.")).isEqualTo(CHINESE);
+        assertThat(detector.detectLanguageOf("上海大学是一个好大学  this is a test.")).isEqualTo(CHINESE);
     }
 }

--- a/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
+++ b/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
@@ -27,7 +27,9 @@ public class LanguageDetectorBuilderJavaTest {
 
     @Test
     public void assertThatLinguaCanBeUsedWithJava() {
-        final LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(CHINESE, ENGLISH, FRENCH).build();
-        assertThat(detector.detectLanguageOf("上海大学是一个好大学  this is a test.")).isEqualTo(CHINESE);
+        final LanguageDetector detector = LanguageDetectorBuilder
+            .fromLanguages(CHINESE, ENGLISH, FRENCH).build();
+        String text = "上海大学是一个好大学  this is a test.";
+        assertThat(detector.detectLanguageOf(text)).isEqualTo(CHINESE);
     }
 }

--- a/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
+++ b/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
@@ -20,16 +20,14 @@ import org.junit.jupiter.api.Test;
 
 import static com.github.pemistahl.lingua.api.Language.ENGLISH;
 import static com.github.pemistahl.lingua.api.Language.FRENCH;
-import static com.github.pemistahl.lingua.api.Language.CHINESE;
+import static com.github.pemistahl.lingua.api.Language.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LanguageDetectorBuilderJavaTest {
 
     @Test
     public void assertThatLinguaCanBeUsedWithJava() {
-        final LanguageDetector detector = LanguageDetectorBuilder
-            .fromLanguages(CHINESE, ENGLISH, FRENCH).build();
-        String text = "上海大学是一个好大学  this is a test.";
-        assertThat(detector.detectLanguageOf(text)).isEqualTo(CHINESE);
+        final LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(GERMAN, ENGLISH, FRENCH).build();
+        assertThat(detector.detectLanguageOf("groß")).isEqualTo(GERMAN);
     }
 }

--- a/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
+++ b/src/test/java/com/github/pemistahl/lingua/api/LanguageDetectorBuilderJavaTest.java
@@ -28,6 +28,6 @@ public class LanguageDetectorBuilderJavaTest {
     @Test
     public void assertThatLinguaCanBeUsedWithJava() {
         final LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(CHINESE, ENGLISH, FRENCH).build();
-        assertThat(detector.detectLanguageOf("上海大学是一个好大学 this is a test.")).isEqualTo(ENGLISH);
+        assertThat(detector.detectLanguageOf("上海大学是一个好大学 this is a test.")).isEqualTo(CHINESE);
     }
 }

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -103,22 +103,31 @@ class LanguageDetectorTest {
 
     @MockK
     private lateinit var unigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var bigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var trigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var quadrigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var fivegramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var unigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var bigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var trigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var quadrigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var fivegramLanguageModelForGerman: TrainingDataLanguageModel
 
@@ -126,8 +135,10 @@ class LanguageDetectorTest {
 
     @MockK
     private lateinit var unigramTestDataLanguageModel: TestDataLanguageModel
+
     @MockK
     private lateinit var trigramTestDataLanguageModel: TestDataLanguageModel
+
     @MockK
     private lateinit var quadrigramTestDataLanguageModel: TestDataLanguageModel
 
@@ -945,5 +956,40 @@ class LanguageDetectorTest {
                 Ngram("wxyz")
             )
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "上海大学是一个好大学this, CHINESE, 11",
+        "this, CHINESE, 1",
+        "上海Test是一个好大学Test, CHINESE, 10",
+    )
+    fun `assert that language of logogram wordCount if exist`(
+        word: String,
+        language: Language,
+        wordSize: Int
+    ) {
+        assertThat(
+            detectorForAllLanguages.logogramWordCountIfExist(language, word)
+        ).isEqualTo(
+            wordSize
+        )
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "上海大学是一个好大学this is a test, CHINESE",
+        "this is a test, ENGLISH",
+        "上海Test是一个好大学Test, CHINESE",
+    )
+    fun `assert that language of logogram wordCount if exist`(
+        word: String,
+        expectedLanguage: Language
+    ) {
+        assertThat(
+            detectorForAllLanguages.detectLanguageOf(word)
+        ).isEqualTo(
+            expectedLanguage
+        )
     }
 }

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -406,7 +406,7 @@ class LanguageDetectorTest {
         "mỹ, VIETNAMESE",
         "mỵ, VIETNAMESE",
         "kōnin, YORUBA",
-        "ṣaaju, YORUBA",C
+        "ṣaaju, YORUBA",
         "والموضوع, UNKNOWN",
         "сопротивление, UNKNOWN",
         "house, UNKNOWN"

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -406,7 +406,7 @@ class LanguageDetectorTest {
         "mỹ, VIETNAMESE",
         "mỵ, VIETNAMESE",
         "kōnin, YORUBA",
-        "ṣaaju, YORUBA",
+        "ṣaaju, YORUBA",C
         "والموضوع, UNKNOWN",
         "сопротивление, UNKNOWN",
         "house, UNKNOWN"


### PR DESCRIPTION
Chinese,Japanse and Korean(CJK), word count split by no space . if text contain english , CJK word may cause some error.
Just like this:  "上海大学是一个好大学 this is a test." will be split to words "上海大学是一个好大学" ,"this" ,"is","a","test".
and will be detected to ENGLISH。 But actually, the text belong to CHINESE, because of CJK word count split by no space.
 "上海大学是一个好大学 this is a test." need to be split to words "上","海","大","学","是","一","个",好","大",学" ,"this" ,"is","a","test".

We need to specific the language, which can be split by space or not. And we can correct  in countword considering by language .
