### PR TITLE
Add functions to return corresponding ISO 639-1 and ISO 639-3 codes

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/Language.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/Language.kt
@@ -319,6 +319,18 @@ enum class Language(
          */
         @JvmStatic
         fun getByIsoCode639_3(isoCode: IsoCode639_3) = values().find { it.isoCode639_3 == isoCode }!!
+        
+        /**
+         * Returns corresponding ISO 639-1 code.
+         */
+        @JvmStatic
+        fun getIsoCode639_1() = it.isoCode639_1
+
+        /**
+         * Returns corresponding ISO 639-3 code.
+         */
+        @JvmStatic
+        fun getByIsoCode639_3() = it.isoCode639_3
 
         private fun filterOutLanguages(vararg languages: Language) = values().filterNot { it in languages }
     }


### PR DESCRIPTION
These functions will be useful to get corresponding  ISO 639-1 and ISO 639-3 codes for a Language object