### PR TITLE
fix: append space in splitTextIntoWord if text contain logogram

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -60,6 +60,7 @@ import com.github.pemistahl.lingua.api.Language.UNKNOWN
 import com.github.pemistahl.lingua.api.Language.VIETNAMESE
 import com.github.pemistahl.lingua.api.Language.YORUBA
 import com.github.pemistahl.lingua.internal.Alphabet
+import com.github.pemistahl.lingua.internal.Constant.LANGUAGES_SUPPORTING_LOGOGRAMS
 import com.github.pemistahl.lingua.internal.Constant.MULTIPLE_WHITESPACE
 import com.github.pemistahl.lingua.internal.Constant.NUMBERS
 import com.github.pemistahl.lingua.internal.Constant.PUNCTUATION
@@ -68,6 +69,7 @@ import com.github.pemistahl.lingua.internal.TestDataLanguageModel
 import com.github.pemistahl.lingua.internal.TrainingDataLanguageModel
 import com.github.pemistahl.lingua.internal.util.extension.containsAnyOf
 import com.github.pemistahl.lingua.internal.util.extension.incrementCounter
+import java.lang.StringBuilder
 import java.util.SortedMap
 import java.util.TreeMap
 import java.util.regex.PatternSyntaxException
@@ -186,11 +188,25 @@ class LanguageDetector internal constructor(
     }
 
     internal fun splitTextIntoWords(text: String): List<String> {
-        return if (text.contains(' ')) {
-            text.split(' ')
+        var appendSpaceIfContainLogogram = appendSpaceIfCharContainInLogogram(text)
+        return if (appendSpaceIfContainLogogram.contains(' ')) {
+            appendSpaceIfContainLogogram.split(' ')
         } else {
             listOf(text)
         }
+    }
+
+    internal fun appendSpaceIfCharContainInLogogram(text: String): String {
+        val processedTextBuilder = StringBuilder()
+        for (character in text.map { it.toString() }) {
+            when {
+                LANGUAGES_SUPPORTING_LOGOGRAMS.stream().flatMap { e -> e.alphabets.stream() }
+                    .anyMatch { e -> e.matches(character) } -> processedTextBuilder.append(character).append(' ')
+                LANGUAGES_SUPPORTING_LOGOGRAMS.stream().flatMap { e -> e.alphabets.stream() }
+                    .noneMatch { e -> e.matches(character) } -> processedTextBuilder.append(character)
+            }
+        }
+        return processedTextBuilder.toString().replace(MULTIPLE_WHITESPACE, " ")
     }
 
     internal fun countUnigramsOfInputText(

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -16,9 +16,12 @@
 
 package com.github.pemistahl.lingua.internal
 
+import com.github.pemistahl.lingua.api.Language
+
 internal object Constant {
 
     val PUNCTUATION = Regex("\\p{P}")
     val NUMBERS = Regex("\\p{N}")
     val MULTIPLE_WHITESPACE = Regex("\\s+")
+    val LANGUAGES_SUPPORTING_LOGOGRAMS = listOf(Language.CHINESE, Language.JAPANESE, Language.KOREAN)
 }

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -103,22 +103,31 @@ class LanguageDetectorTest {
 
     @MockK
     private lateinit var unigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var bigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var trigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var quadrigramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var fivegramLanguageModelForEnglish: TrainingDataLanguageModel
+
     @MockK
     private lateinit var unigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var bigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var trigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var quadrigramLanguageModelForGerman: TrainingDataLanguageModel
+
     @MockK
     private lateinit var fivegramLanguageModelForGerman: TrainingDataLanguageModel
 
@@ -126,8 +135,10 @@ class LanguageDetectorTest {
 
     @MockK
     private lateinit var unigramTestDataLanguageModel: TestDataLanguageModel
+
     @MockK
     private lateinit var trigramTestDataLanguageModel: TestDataLanguageModel
+
     @MockK
     private lateinit var quadrigramTestDataLanguageModel: TestDataLanguageModel
 
@@ -452,6 +463,41 @@ class LanguageDetectorTest {
         )
     }
 
+    @ParameterizedTest
+    @CsvSource(
+        "上海大学112, 上 海 大 学 112",
+        "this is test 2, this is test 2",
+        "上this 大is test 2, 上 this 大 is test 2",
+        "上海是一个好地方，Beijing is famous place, 上 海 是 一 个 好 地 方 ，Beijing is famous place",
+        "这是一个测 试this is test 2, 这 是 一 个 测 试 this is test 2",
+        "哈哈，上this 大is test 2, 哈 哈 ，上 this 大 is test 2"
+    )
+    fun `assert that append space if the character in logogram`(
+        text: String,
+        processedText: String
+    ) {
+        assertThat(
+            detectorForAllLanguages.appendSpaceIfCharContainInLogogram(text)
+        ).isEqualTo(
+            processedText
+        )
+    }
+    @ParameterizedTest
+    @CsvSource(
+        "上海是一个好地方，Beijing is famous place, 12",
+        "这是一个测 试this is test 2, 10",
+        "哈哈，上this 大is test 2, 8"
+    )
+    fun `assert that split text into words with logogram`(
+        text: String,
+        wordSize: Int
+    ) {
+        assertThat(
+            detectorForAllLanguages.splitTextIntoWords(text).size
+        ).isEqualTo(
+            wordSize
+        )
+    }
     // language filtering with rules
 
     private fun filteredLanguagesProvider() = listOf(


### PR DESCRIPTION
I closed the previous request [Fix word splitting algorithm for languages supporting logograms](https://github.com/pemistahl/lingua/pull/81). And i open a new request, because i find that appending space in splitTextIntoWord is most easy way to sovle this issue.