### PR TITLE
Add Gradle wrapper validation workflow

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Adds a workflow running the [Gradle wrapper validation action](https://github.com/gradle/wrapper-validation-action#the-gradle-wrapper-problem-in-open-source).
This makes sure only legit Gradle wrapper binaries are used.