### PR TITLE
Improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import ru.vyarus.gradle.plugin.python.task.PythonTask
+import java.util.Locale
 
 val linguaTaskGroup: String by project
 val linguaGroupId: String by project
@@ -171,7 +172,7 @@ tasks.register<Test>("accuracyReport") {
             languages.forEach { language ->
                 includeTestsMatching(
                     "$linguaGroupId.$linguaArtifactId.report" +
-                        ".${detector.toLowerCase()}.${language}DetectionAccuracyReport"
+                        ".${detector.toLowerCase(Locale.ROOT)}.${language}DetectionAccuracyReport"
                 )
             }
         }
@@ -204,13 +205,18 @@ tasks.register("writeAggregatedAccuracyReport") {
             csvFile.appendText(language)
 
             for (detector in detectors) {
-                val languageReportFileName = "$accuracyReportsDirectoryName/${detector.toLowerCase()}/$language.txt"
+                val languageReportFileName =
+                    "$accuracyReportsDirectoryName/${detector.toLowerCase(Locale.ROOT)}/$language.txt"
                 val languageReportFile = file(languageReportFileName)
 
                 if (languageReportFile.exists()) {
                     for (line in languageReportFile.readLines()) {
                         if (line.startsWith(stringToSplitAt)) {
-                            val accuracyValues = line.split(stringToSplitAt)[1].split(' ').slice(1..4).joinToString(",")
+                            val accuracyValues = line
+                                .split(stringToSplitAt)[1]
+                                .split(' ')
+                                .slice(1..4)
+                                .joinToString(",")
                             csvFile.appendText(",")
                             csvFile.appendText(accuracyValues)
                         }

--- a/src/accuracyReport/kotlin/com/github/pemistahl/lingua/report/AbstractLanguageDetectionAccuracyReport.kt
+++ b/src/accuracyReport/kotlin/com/github/pemistahl/lingua/report/AbstractLanguageDetectionAccuracyReport.kt
@@ -86,8 +86,8 @@ abstract class AbstractLanguageDetectionAccuracyReport(
     fun afterAll() {
         val projectRootPath = Paths.get("").toAbsolutePath().toString()
         val accuracyReportsDirectoryName = "accuracy-reports"
-        val detectorDirectoryName = implementationToUse.name.toLowerCase()
-        val languageReportFileName = "${language.name.toLowerCase().capitalize()}.txt"
+        val detectorDirectoryName = implementationToUse.name.toLowerCase(Locale.ROOT)
+        val languageReportFileName = "${language.name.toLowerCase(Locale.ROOT).capitalize()}.txt"
         val accuracyReportsDirectoryPath = Paths.get(
             projectRootPath,
             accuracyReportsDirectoryName,
@@ -184,7 +184,7 @@ abstract class AbstractLanguageDetectionAccuracyReport(
             OPENNLP -> {
                 val detectedLanguage = opennlpDetector.predictLanguage(element)
                 val isoCode = try {
-                    val isoCode = detectedLanguage.lang.toUpperCase()
+                    val isoCode = detectedLanguage.lang.toUpperCase(Locale.ROOT)
                     IsoCode639_3.valueOf(mapOpenNlpIsoCodeToLinguaIsoCode(isoCode))
                 } catch (e: IllegalArgumentException) {
                     IsoCode639_3.NONE
@@ -249,7 +249,7 @@ abstract class AbstractLanguageDetectionAccuracyReport(
         return when {
             !locale.isPresent -> UNKNOWN
             locale.get().language.startsWith("zh") -> CHINESE
-            else -> Language.getByIsoCode639_1(IsoCode639_1.valueOf(locale.get().language.toUpperCase()))
+            else -> Language.getByIsoCode639_1(IsoCode639_1.valueOf(locale.get().language.toUpperCase(Locale.ROOT)))
         }
     }
 
@@ -257,7 +257,7 @@ abstract class AbstractLanguageDetectionAccuracyReport(
         return when {
             result.isUnknown -> UNKNOWN
             result.language.startsWith("zh") -> CHINESE
-            else -> Language.getByIsoCode639_1(IsoCode639_1.valueOf(result.language.toUpperCase()))
+            else -> Language.getByIsoCode639_1(IsoCode639_1.valueOf(result.language.toUpperCase(Locale.ROOT)))
         }
     }
 

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/IsoCode639_1.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/IsoCode639_1.kt
@@ -16,6 +16,8 @@
 
 package com.github.pemistahl.lingua.api
 
+import java.util.Locale
+
 /**
  * The ISO 639-1 code representations for the supported languages.
  *
@@ -403,5 +405,5 @@ enum class IsoCode639_1 {
      */
     NONE;
 
-    override fun toString() = this.name.toLowerCase()
+    override fun toString() = this.name.toLowerCase(Locale.ROOT)
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/IsoCode639_3.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/IsoCode639_3.kt
@@ -16,6 +16,8 @@
 
 package com.github.pemistahl.lingua.api
 
+import java.util.Locale
+
 /**
  * The ISO 639-3 code representations for the supported languages.
  *
@@ -403,5 +405,5 @@ enum class IsoCode639_3 {
      */
     NONE;
 
-    override fun toString() = this.name.toLowerCase()
+    override fun toString() = this.name.toLowerCase(Locale.ROOT)
 }

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -21,11 +21,11 @@ import com.github.pemistahl.lingua.api.Language.JAPANESE
 import com.github.pemistahl.lingua.api.Language.UNKNOWN
 import com.github.pemistahl.lingua.internal.Alphabet
 import com.github.pemistahl.lingua.internal.Constant.CHARS_TO_LANGUAGES_MAPPING
-import com.github.pemistahl.lingua.internal.Constant.JAPANESE_CHARACTER_SET
 import com.github.pemistahl.lingua.internal.Constant.MULTIPLE_WHITESPACE
 import com.github.pemistahl.lingua.internal.Constant.NO_LETTER
 import com.github.pemistahl.lingua.internal.Constant.NUMBERS
 import com.github.pemistahl.lingua.internal.Constant.PUNCTUATION
+import com.github.pemistahl.lingua.internal.Constant.isJapaneseAlphabet
 import com.github.pemistahl.lingua.internal.Ngram
 import com.github.pemistahl.lingua.internal.TestDataLanguageModel
 import com.github.pemistahl.lingua.internal.TrainingDataLanguageModel
@@ -223,7 +223,7 @@ class LanguageDetector internal constructor(
         for (word in words) {
             val wordLanguageCounts = mutableMapOf<Language, Int>()
 
-            for (character in word.map { it.toString() }) {
+            for (character in word) {
                 var isMatch = false
                 for ((alphabet, language) in alphabetsSupportingExactlyOneLanguage) {
                     if (alphabet.matches(character)) {
@@ -234,7 +234,7 @@ class LanguageDetector internal constructor(
                 if (!isMatch) {
                     when {
                         Alphabet.HAN.matches(character) -> wordLanguageCounts.incrementCounter(CHINESE)
-                        JAPANESE_CHARACTER_SET.matches(character) -> wordLanguageCounts.incrementCounter(JAPANESE)
+                        isJapaneseAlphabet(character) -> wordLanguageCounts.incrementCounter(JAPANESE)
                         Alphabet.LATIN.matches(character) ||
                             Alphabet.CYRILLIC.matches(character) ||
                             Alphabet.DEVANAGARI.matches(character) ->

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -179,7 +179,13 @@ class LanguageDetector internal constructor(
                 }
                 nextWordStart = i + 1
             } else if (char.isLogogram()) {
-                words.add(text.substring(nextWordStart, i + 1))
+                if (nextWordStart != i) {
+                    // Add previous word excluding trailing logogram
+                    words.add(text.substring(nextWordStart, i))
+                }
+
+                // Add logogram on its own
+                words.add(text[i].toString())
                 nextWordStart = i + 1
             }
         }

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
+import java.util.Locale
 import java.util.SortedMap
 import java.util.TreeMap
 import kotlin.math.ln
@@ -161,7 +162,7 @@ class LanguageDetector internal constructor(
     }
 
     internal fun cleanUpInputText(text: String): String {
-        return text.trim().toLowerCase()
+        return text.trim().toLowerCase(Locale.ROOT)
             .replace(PUNCTUATION, "")
             .replace(NUMBERS, "")
             .replace(MULTIPLE_WHITESPACE, " ")

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -238,6 +238,9 @@ class LanguageDetector internal constructor(
                     if (alphabet.matches(character)) {
                         wordLanguageCounts.incrementCounter(language)
                         isMatch = true
+                        // Each code point can only belong to one alphabet, therefore can break
+                        // as soon as a match is found
+                        break
                     }
                 }
                 if (!isMatch) {

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -71,15 +71,12 @@ class LanguageDetector internal constructor(
         val confidenceValues = computeLanguageConfidenceValues(text)
 
         if (confidenceValues.isEmpty()) return UNKNOWN
-        if (confidenceValues.size == 1) return confidenceValues.firstKey()
 
         val mostLikelyLanguage = confidenceValues.firstKey()
-        val mostLikelyLanguageProbability = confidenceValues.getValue(mostLikelyLanguage)
+        if (confidenceValues.size == 1) return mostLikelyLanguage
 
-        val secondMostLikelyLanguage = confidenceValues.filterNot {
-            it.key == mostLikelyLanguage
-        }.maxByOrNull { it.value }!!.key
-        val secondMostLikelyLanguageProbability = confidenceValues.getValue(secondMostLikelyLanguage)
+        val mostLikelyLanguageProbability = confidenceValues.getValue(mostLikelyLanguage)
+        val secondMostLikelyLanguageProbability = confidenceValues.values.elementAt(1)
 
         return when {
             mostLikelyLanguageProbability == secondMostLikelyLanguageProbability -> UNKNOWN

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/io/TestDataFilesWriter.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/io/TestDataFilesWriter.kt
@@ -24,6 +24,7 @@ import com.github.pemistahl.lingua.internal.io.FilesWriter
 import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Locale
 
 object TestDataFilesWriter : FilesWriter() {
 
@@ -131,7 +132,7 @@ object TestDataFilesWriter : FilesWriter() {
                     .replace(MULTIPLE_WHITESPACE, " ")
                     .replace("\"", "")
                     .split(' ')
-                    .map { it.trim().toLowerCase() }
+                    .map { it.trim().toLowerCase(Locale.ROOT) }
                     .filter { wordRegex.matches(it) }
 
                 words.addAll(singleWords)

--- a/src/main/kotlin/com/github/pemistahl/lingua/app/App.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/app/App.kt
@@ -21,6 +21,7 @@ import com.github.pemistahl.lingua.api.LanguageDetectorBuilder
 import com.github.pemistahl.lingua.api.LanguageDetectorBuilder.Companion.fromAllLanguages
 import com.github.pemistahl.lingua.api.LanguageDetectorBuilder.Companion.fromIsoCodes639_1
 import java.io.Console
+import java.util.Locale
 import java.util.Scanner
 
 fun main() {
@@ -102,7 +103,7 @@ private fun runApp() {
 
                 for (isoCode in isoCodesList) {
                     try {
-                        isoCodes.add(IsoCode639_1.valueOf(isoCode.toUpperCase()))
+                        isoCodes.add(IsoCode639_1.valueOf(isoCode.toUpperCase(Locale.ROOT)))
                     } catch (e: IllegalArgumentException) {
                         isoCodes.clear()
                         println("Iso code '$isoCode' is not supported. Try again.\n")

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -60,7 +60,6 @@ import com.github.pemistahl.lingua.api.Language.TURKISH
 import com.github.pemistahl.lingua.api.Language.UKRAINIAN
 import com.github.pemistahl.lingua.api.Language.VIETNAMESE
 import com.github.pemistahl.lingua.api.Language.YORUBA
-import java.util.regex.PatternSyntaxException
 
 internal object Constant {
 
@@ -119,11 +118,14 @@ internal object Constant {
             ITALIAN, PORTUGUESE, SLOVAK, SPANISH, VIETNAMESE, YORUBA
         )
     )
-    val JAPANESE_CHARACTER_SET = try {
-        Regex("^[\\p{Hiragana}\\p{Katakana}\\p{Han}]+$")
-    } catch (e: PatternSyntaxException) {
-        Regex("^[\\p{IsHiragana}\\p{IsKatakana}\\p{IsHan}]+$")
+
+    fun isJapaneseAlphabet(char: Char): Boolean {
+        val script = Character.UnicodeScript.of(char.toInt())
+        return script == Character.UnicodeScript.HIRAGANA ||
+            script == Character.UnicodeScript.KATAKANA ||
+            script == Character.UnicodeScript.HAN
     }
+
     val LANGUAGES_SUPPORTING_LOGOGRAMS = setOf(CHINESE, JAPANESE, KOREAN)
     val MULTIPLE_WHITESPACE = Regex("\\s+")
     val NO_LETTER = Regex("^[^\\p{L}]+$")

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Ngram.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Ngram.kt
@@ -42,7 +42,7 @@ internal data class Ngram(val value: String) : Comparable<Ngram> {
     fun rangeOfLowerOrderNgrams() = NgramRange(this, Ngram(this.value[0].toString()))
 
     operator fun dec(): Ngram = when {
-        this.value.length > 1 -> Ngram(this.value.slice(0..this.value.length - 2))
+        this.value.length > 1 -> Ngram(this.value.substring(0, this.value.length - 1))
         this.value.length == 1 -> Ngram("")
         else -> throw IllegalStateException(
             "Zerogram is ngram type of lowest order and can not be decremented"

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/TestDataLanguageModel.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/TestDataLanguageModel.kt
@@ -27,7 +27,7 @@ internal data class TestDataLanguageModel(val ngrams: Set<Ngram>) {
             }
             val ngrams = hashSetOf<Ngram>()
             for (i in 0..text.length - ngramLength) {
-                val textSlice = text.slice(i until i + ngramLength)
+                val textSlice = text.substring(i, i + ngramLength)
                 if (LETTER_REGEX.matches(textSlice)) {
                     val ngram = Ngram(textSlice)
                     ngrams.add(ngram)

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModel.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModel.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.util.Locale
 
 @Serializable
 internal data class JsonLanguageModel(val language: Language, val ngrams: Map<Fraction, String>)
@@ -110,7 +111,7 @@ internal data class TrainingDataLanguageModel(
             val regex = Regex("[$charClass]+")
 
             for (line in text) {
-                val lowerCasedLine = line.toLowerCase()
+                val lowerCasedLine = line.toLowerCase(Locale.ROOT)
                 for (i in 0..lowerCasedLine.length - ngramLength) {
                     val textSlice = lowerCasedLine.slice(i until i + ngramLength)
                     if (regex.matches(textSlice)) {

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModel.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModel.kt
@@ -117,7 +117,7 @@ internal data class TrainingDataLanguageModel(
             for (line in text) {
                 val lowerCasedLine = line.toLowerCase(Locale.ROOT)
                 for (i in 0..lowerCasedLine.length - ngramLength) {
-                    val textSlice = lowerCasedLine.slice(i until i + ngramLength)
+                    val textSlice = lowerCasedLine.substring(i, i + ngramLength)
                     if (regex.matches(textSlice)) {
                         val ngram = Ngram(textSlice)
                         absoluteFrequencies.incrementCounter(ngram)
@@ -141,7 +141,7 @@ internal data class TrainingDataLanguageModel(
                 val denominator = if (ngramLength == 1 || lowerNgramAbsoluteFrequencies.isEmpty()) {
                     totalNgramFrequency
                 } else {
-                    lowerNgramAbsoluteFrequencies.getValue(Ngram(ngram.value.slice(0..ngramLength - 2)))
+                    lowerNgramAbsoluteFrequencies.getValue(Ngram(ngram.value.substring(0, ngramLength - 1)))
                 }
                 ngramProbabilities[ngram] = Fraction(frequency, denominator)
             }

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/CharExtensions.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/CharExtensions.kt
@@ -16,15 +16,18 @@
 
 package com.github.pemistahl.lingua.internal.util.extension
 
+import com.github.pemistahl.lingua.api.Language
 import com.github.pemistahl.lingua.internal.Constant.LANGUAGES_SUPPORTING_LOGOGRAMS
+
+// Cache set of scripts here to avoid evaluating it every time for isLogogram()
+private val scriptsWithLogograms = LANGUAGES_SUPPORTING_LOGOGRAMS.asSequence()
+    .flatMap(Language::alphabets)
+    .toSet()
 
 fun Char.isLogogram(): Boolean {
     return if (this.isWhitespace()) {
         false
     } else {
-        LANGUAGES_SUPPORTING_LOGOGRAMS
-            .asSequence()
-            .flatMap { it.alphabets }
-            .any { it.matches(this) }
+        scriptsWithLogograms.any { it.matches(this) }
     }
 }

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/io/LanguageModelFilesWriterTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/io/LanguageModelFilesWriterTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.condition.OS.WINDOWS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Locale
 import java.util.stream.Collectors.toList
 
 class LanguageModelFilesWriterTest {
@@ -37,7 +38,7 @@ class LanguageModelFilesWriterTest {
         These sentences are intended for testing purposes.
         Do not use them in production!
         By the way, they consist of 23 words in total.
-        """.toLowerCase().trimIndent()
+        """.toLowerCase(Locale.ROOT).trimIndent()
 
     private val expectedUnigramLanguageModel =
         """

--- a/src/test/kotlin/com/github/pemistahl/lingua/internal/TestDataLanguageModelTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/internal/TestDataLanguageModelTest.kt
@@ -18,6 +18,7 @@ package com.github.pemistahl.lingua.internal
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class TestDataLanguageModelTest {
 
@@ -26,7 +27,7 @@ class TestDataLanguageModelTest {
         These sentences are intended for testing purposes.
         Do not use them in production!
         By the way, they consist of 23 words in total.
-        """.toLowerCase().trimIndent()
+        """.toLowerCase(Locale.ROOT).trimIndent()
 
     @Test
     fun `assert that unigram language model can be created from test data`() {

--- a/src/test/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModelTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModelTest.kt
@@ -19,6 +19,7 @@ package com.github.pemistahl.lingua.internal
 import com.github.pemistahl.lingua.api.Language
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class TrainingDataLanguageModelTest {
 
@@ -27,7 +28,7 @@ class TrainingDataLanguageModelTest {
         These sentences are intended for testing purposes.
         Do not use them in production!
         By the way, they consist of 23 words in total.
-        """.toLowerCase().trimIndent()
+        """.toLowerCase(Locale.ROOT).trimIndent()
 
     private val keyMapper = { entry: Map.Entry<String, Any> -> Ngram(entry.key) }
 

--- a/src/test/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModelTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModelTest.kt
@@ -269,7 +269,7 @@ class TrainingDataLanguageModelTest {
         assertThat(model.absoluteFrequencies).isEmpty()
         assertThat(model.relativeFrequencies).isEmpty()
         assertThat(model.jsonRelativeFrequencies).containsExactlyInAnyOrderEntriesOf(
-            expectedUnigramJsonRelativeFrequencies
+            expectedUnigramJsonRelativeFrequencies.mapKeys { it.key.value }
         )
     }
 }


### PR DESCRIPTION
Some minor improvements:
- Use `Locale.ROOT` for case conversion; `toLowerCase()` and `toUpperCase()` without explicit `Locale` use the system dependent default Locale
- Call [`trim()`](https://fastutil.di.unimi.it/docs/it/unimi/dsi/fastutil/objects/Object2DoubleOpenHashMap.html#trim()) after having loaded JSON language models. This sounds quite simple but can safe multiple megabytes of memory.
- Directly store `String` in ngram map instead of wrapping it in `Ngram`.
- Don't use Regex to determine whether character is Japanese, instead use the respective `UnicodeScript` constants. This avoids calling `toString()` for every char and `Matcher` (during matching), and is less error-prone than Regex patterns which are not supported on some platforms (e.g. Android).
- Reduce object creations:
  - When splitting into words directly store the results in a list instead of first creating a `StringBuilder` and then splitting again.
  - Avoid calling `String.slice(IntRange)`, this causes unnecessary memory allocations for the `IntRange`, see also https://github.com/detekt/detekt/issues/3823. Instead just call `substring(Int, Int)`.

(Note that these are not the major performance improvements I mentioned recently, ~~I will write an issue for that soon~~ they are described in #101.)