### PR TITLE
Change Ngram to value class to reduce memory indirection

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Ngram.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Ngram.kt
@@ -23,8 +23,9 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@JvmInline
 @Serializable(with = NgramSerializer::class)
-internal data class Ngram(val value: String) : Comparable<Ngram> {
+internal value class Ngram(val value: String) : Comparable<Ngram> {
     init {
         require(value.length in 0..5) {
             "length of ngram '$value' is not in range 0..5"
@@ -33,20 +34,14 @@ internal data class Ngram(val value: String) : Comparable<Ngram> {
 
     override fun toString() = value
 
-    override fun compareTo(other: Ngram) = when {
-        this.value.length > other.value.length -> 1
-        this.value.length < other.value.length -> -1
-        else -> 0
-    }
+    override fun compareTo(other: Ngram) = value.length.compareTo(other.value.length)
 
     fun rangeOfLowerOrderNgrams() = NgramRange(this, Ngram(this.value[0].toString()))
 
-    operator fun dec(): Ngram = when {
-        this.value.length > 1 -> Ngram(this.value.substring(0, this.value.length - 1))
-        this.value.length == 1 -> Ngram("")
-        else -> throw IllegalStateException(
-            "Zerogram is ngram type of lowest order and can not be decremented"
-        )
+    operator fun dec(): Ngram = when(value.length) {
+        0 -> error("Zerogram is ngram type of lowest order and can not be decremented")
+        1 -> Ngram("")
+        else -> Ngram(this.value.substring(0, this.value.length - 1))
     }
 
     companion object {

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
@@ -16,6 +16,4 @@
 
 package com.github.pemistahl.lingua.internal.util.extension
 
-internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) {
-    this[key] = this.getOrDefault(key, 0) + 1
-}
+internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) = this.merge(key, 1, Int::plus)

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -212,17 +212,17 @@ class LanguageDetectorTest {
     // ngram probability lookup
 
     private fun ngramProbabilityProvider() = listOf(
-        arguments(ENGLISH, Ngram("a"), 0.01),
-        arguments(ENGLISH, Ngram("lt"), 0.12),
-        arguments(ENGLISH, Ngram("ter"), 0.21),
-        arguments(ENGLISH, Ngram("alte"), 0.25),
-        arguments(ENGLISH, Ngram("alter"), 0.29),
+        arguments(ENGLISH, "a", 0.01),
+        arguments(ENGLISH, "lt", 0.12),
+        arguments(ENGLISH, "ter", 0.21),
+        arguments(ENGLISH, "alte", 0.25),
+        arguments(ENGLISH, "alter", 0.29),
 
-        arguments(GERMAN, Ngram("t"), 0.08),
-        arguments(GERMAN, Ngram("er"), 0.18),
-        arguments(GERMAN, Ngram("alt"), 0.22),
-        arguments(GERMAN, Ngram("lter"), 0.28),
-        arguments(GERMAN, Ngram("alter"), 0.30)
+        arguments(GERMAN, "t", 0.08),
+        arguments(GERMAN, "er", 0.18),
+        arguments(GERMAN, "alt", 0.22),
+        arguments(GERMAN, "lter", 0.28),
+        arguments(GERMAN, "alter", 0.30)
     )
 
     @ParameterizedTest


### PR DESCRIPTION
Reduce `Ngram` memory allocation and avoid memory redirection (#101).
These changes don't modify the public interface.