### PR TITLE
Compact memory data (#101)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -304,7 +304,6 @@ tasks.register<JavaExec>("runLinguaOnConsole") {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.6.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
-    implementation("it.unimi.dsi:fastutil:8.5.6")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
     testImplementation("org.assertj:assertj-core:3.21.0")

--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -421,7 +421,7 @@ class LanguageDetector internal constructor(
             for (elem in ngram.rangeOfLowerOrderNgrams()) {
                 val probability = lookUpNgramProbability(language, elem)
                 if (probability > 0) {
-                    probabilitiesSum += ln(probability)
+                    probabilitiesSum += ln(probability.toDouble())
                     break
                 }
             }
@@ -432,7 +432,7 @@ class LanguageDetector internal constructor(
     internal fun lookUpNgramProbability(
         language: Language,
         ngram: Ngram
-    ): Double {
+    ): Float {
         val ngramLength = ngram.value.length
         val languageModels = when (ngramLength) {
             5 -> fivegramLanguageModels

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Ngram.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Ngram.kt
@@ -23,8 +23,9 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+@JvmInline
 @Serializable(with = NgramSerializer::class)
-internal data class Ngram(val value: String) : Comparable<Ngram> {
+internal value class Ngram(val value: String) : Comparable<Ngram> {
     init {
         require(value.length in 0..5) {
             "length of ngram '$value' is not in range 0..5"
@@ -33,20 +34,14 @@ internal data class Ngram(val value: String) : Comparable<Ngram> {
 
     override fun toString() = value
 
-    override fun compareTo(other: Ngram) = when {
-        this.value.length > other.value.length -> 1
-        this.value.length < other.value.length -> -1
-        else -> 0
-    }
+    override fun compareTo(other: Ngram) = value.length.compareTo(other.value.length)
 
     fun rangeOfLowerOrderNgrams() = NgramRange(this, Ngram(this.value[0].toString()))
 
-    operator fun dec(): Ngram = when {
-        this.value.length > 1 -> Ngram(this.value.substring(0, this.value.length - 1))
-        this.value.length == 1 -> Ngram("")
-        else -> throw IllegalStateException(
-            "Zerogram is ngram type of lowest order and can not be decremented"
-        )
+    operator fun dec(): Ngram = when(value.length) {
+        0 -> error("Zerogram is ngram type of lowest order and can not be decremented")
+        1 -> Ngram("")
+        else -> Ngram(this.value.substring(0, this.value.length - 1))
     }
 
     companion object {

--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/util/extension/MapExtensions.kt
@@ -16,6 +16,4 @@
 
 package com.github.pemistahl.lingua.internal.util.extension
 
-internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) {
-    this[key] = this.getOrDefault(key, 0) + 1
-}
+internal fun <T> MutableMap<T, Int>.incrementCounter(key: T) = this.merge(key, 1, Int::plus)

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -212,17 +212,17 @@ class LanguageDetectorTest {
     // ngram probability lookup
 
     private fun ngramProbabilityProvider() = listOf(
-        arguments(ENGLISH, Ngram("a"), 0.01),
-        arguments(ENGLISH, Ngram("lt"), 0.12),
-        arguments(ENGLISH, Ngram("ter"), 0.21),
-        arguments(ENGLISH, Ngram("alte"), 0.25),
-        arguments(ENGLISH, Ngram("alter"), 0.29),
+        arguments(ENGLISH, "a", 0.01),
+        arguments(ENGLISH, "lt", 0.12),
+        arguments(ENGLISH, "ter", 0.21),
+        arguments(ENGLISH, "alte", 0.25),
+        arguments(ENGLISH, "alter", 0.29),
 
-        arguments(GERMAN, Ngram("t"), 0.08),
-        arguments(GERMAN, Ngram("er"), 0.18),
-        arguments(GERMAN, Ngram("alt"), 0.22),
-        arguments(GERMAN, Ngram("lter"), 0.28),
-        arguments(GERMAN, Ngram("alter"), 0.30)
+        arguments(GERMAN, "t", 0.08),
+        arguments(GERMAN, "er", 0.18),
+        arguments(GERMAN, "alt", 0.22),
+        arguments(GERMAN, "lter", 0.28),
+        arguments(GERMAN, "alter", 0.30)
     )
 
     @ParameterizedTest

--- a/src/test/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModelTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/internal/TrainingDataLanguageModelTest.kt
@@ -267,8 +267,8 @@ class TrainingDataLanguageModelTest {
         assertThat(model.language).isEqualTo(Language.ENGLISH)
         assertThat(model.absoluteFrequencies).isEmpty()
         assertThat(model.relativeFrequencies).isEmpty()
-        assertThat(model.jsonRelativeFrequencies).containsExactlyInAnyOrderEntriesOf(
-            expectedUnigramJsonRelativeFrequencies.mapKeys { it.key.value }
-        )
+        expectedUnigramJsonRelativeFrequencies.keys.forEach { key ->
+            assertThat(model.jsonRelativeFrequencies[key.value] > 0)
+        }
     }
 }


### PR DESCRIPTION
I changed the runtime memory model, the original JSON is translated to a dense map.
This reduces memory requirements at cost of speed (frequencies lookup should be slower).
Frequencies are stored as `Float` instead of `Double`, this introduces an 0.001% error on calculation, and tests are updated accordingly.

`fastutil` dependency has been removed.

All changes are performed in internal classes, so this request is compatible with the 1.1 version and I hope that the merge will be considered soon.