### PR TITLE
Fix mixed line endings in accuracy reports on Windows

### DIFF
--- a/src/accuracyReport/kotlin/com/github/pemistahl/lingua/report/AbstractLanguageDetectionAccuracyReport.kt
+++ b/src/accuracyReport/kotlin/com/github/pemistahl/lingua/report/AbstractLanguageDetectionAccuracyReport.kt
@@ -141,7 +141,7 @@ abstract class AbstractLanguageDetectionAccuracyReport(
             wordPairAccuracyReport,
             sentenceAccuracyReport
         )
-        val newlines = System.lineSeparator().repeat(2)
+        val newlines = "\n".repeat(2)
         var report = "##### $language #####"
         for (reportPart in reportParts)
             if (reportPart.isNotEmpty())
@@ -150,7 +150,8 @@ abstract class AbstractLanguageDetectionAccuracyReport(
         report += newlines
         report += ">> Exact values: $averageAccuracy $singleWordAccuracy $wordPairAccuracy $sentenceAccuracy"
 
-        return report
+        // Normalize line separators
+        return report.replace(Regex("\\R"), System.lineSeparator())
     }
 
     protected fun computeSingleWordStatistics(singleWord: String) {


### PR DESCRIPTION
Previously due to the mixed line endings this caused Git to show the files as changed even though only their line endings in the working tree differed from the index, with the `core.autocrlf` setting not having any effect on it at all. This behavior of Git for files with mixed line endings has also been observed in [this StackOverflow answer](https://stackoverflow.com/a/14039909).

For example, on Windows with `core.autocrlf true`, when I ran `./gradlew accuracyReport -Pdetectors=Lingua` it would report all accuracy reports as modified, just due to their line endings differences.

The reason why they were mixed is because the following multiline string always uses `\n`, but in `statisticsReport()` these sections were joined with `System.lineSeparator()` (`\r\n` on Windows):
https://github.com/pemistahl/lingua/blob/4ca58ead2d2ce6bad6d85574b7efd5b3ca29aa4b/src/accuracyReport/kotlin/com/github/pemistahl/lingua/report/AbstractLanguageDetectionAccuracyReport.kt#L227-L233

For consistency I used `\n` to join all sections now, and changed it to convert all line endings to the `System.lineSeparator()` in the end.