### PR TITLE
Improve JSON model reading

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt
@@ -498,7 +498,7 @@ class LanguageDetector internal constructor(
             val fileName = "${Ngram.getNgramNameByLength(ngramLength)}s.json"
             val filePath = "/language-models/${language.isoCode639_1}/$fileName"
             val inputStream = Language::class.java.getResourceAsStream(filePath) ?: return Object2FloatOpenHashMap()
-            return TrainingDataLanguageModel.fromJson(inputStream)
+            return inputStream.use(TrainingDataLanguageModel::fromJson)
         }
     }
 }


### PR DESCRIPTION
- Instead of using `Buffer().readFrom(json)` which seems to eagerly read the complete `InputStream` content, use `json.source().buffer()` which reads it in a streaming way
- Replaces regex for matching fraction JSON name and instead uses nested loop, which also more closely matches the actual JSON structure