### PR TITLE
Support disabling loading of quadrigram and fivegram models

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorBuilder.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorBuilder.kt
@@ -22,12 +22,18 @@ package com.github.pemistahl.lingua.api
 class LanguageDetectorBuilder private constructor(
     internal val languages: List<Language>,
     internal var minimumRelativeDistance: Double = 0.0,
+    internal var withoutQuadriAndFivegram: Boolean = false,
     internal var isEveryLanguageModelPreloaded: Boolean = false
 ) {
     /**
      * Creates and returns the configured instance of [LanguageDetector].
      */
-    fun build() = LanguageDetector(languages.toMutableSet(), minimumRelativeDistance, isEveryLanguageModelPreloaded)
+    fun build() = LanguageDetector(
+        languages.toMutableSet(),
+        minimumRelativeDistance,
+        withoutQuadriAndFivegram,
+        isEveryLanguageModelPreloaded
+    )
 
     /**
      * Sets the desired value for the minimum relative distance measure.
@@ -55,6 +61,22 @@ class LanguageDetectorBuilder private constructor(
     fun withMinimumRelativeDistance(distance: Double): LanguageDetectorBuilder {
         require(distance in 0.0..0.99) { "minimum relative distance must lie in between 0.0 and 0.99" }
         this.minimumRelativeDistance = distance
+        return this
+    }
+
+    /**
+     * Configures the language detector to not use quadrigram and fivegram language models for
+     * language detection. This affects both dynamically loaded models as well as
+     * [preloaded models][withPreloadedLanguageModels].
+     *
+     * Usually quadrigram and fivegram models are quite large and disabling them therefore can
+     * greatly reduce memory usage during runtime. For larger texts with more than about 150
+     * characters in cleaned up form (without punctuation and with normalized whitespace) this
+     * should not have any noticeable effect on the language detection accuracy. However, for
+     * shorter texts this will make language detection a lot less accurate.
+     */
+    fun withoutQuadrigramAndFivegramModels(): LanguageDetectorBuilder {
+        this.withoutQuadriAndFivegram = true
         return this
     }
 

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorBuilderTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorBuilderTest.kt
@@ -30,11 +30,13 @@ class LanguageDetectorBuilderTest {
 
         assertThat(builder.languages).isEqualTo(Language.all())
         assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+        assertThat(builder.withoutQuadriAndFivegram).isFalse
         assertThat(builder.isEveryLanguageModelPreloaded).isFalse
         assertThat(builder.build()).isEqualTo(
             LanguageDetector(
                 Language.all().toMutableSet(),
                 minimumRelativeDistance = 0.0,
+                withoutQuadriAndFivegram = false,
                 isEveryLanguageModelPreloaded = false
             )
         )
@@ -44,6 +46,7 @@ class LanguageDetectorBuilderTest {
             LanguageDetector(
                 Language.all().toMutableSet(),
                 minimumRelativeDistance = 0.2,
+                withoutQuadriAndFivegram = false,
                 isEveryLanguageModelPreloaded = false
             )
         )
@@ -55,11 +58,13 @@ class LanguageDetectorBuilderTest {
 
         assertThat(builder.languages).isEqualTo(Language.allSpokenOnes())
         assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+        assertThat(builder.withoutQuadriAndFivegram).isFalse
         assertThat(builder.isEveryLanguageModelPreloaded).isFalse
         assertThat(builder.build()).isEqualTo(
             LanguageDetector(
                 Language.allSpokenOnes().toMutableSet(),
                 minimumRelativeDistance = 0.0,
+                withoutQuadriAndFivegram = false,
                 isEveryLanguageModelPreloaded = false
             )
         )
@@ -69,6 +74,7 @@ class LanguageDetectorBuilderTest {
             LanguageDetector(
                 Language.allSpokenOnes().toMutableSet(),
                 minimumRelativeDistance = 0.2,
+                withoutQuadriAndFivegram = false,
                 isEveryLanguageModelPreloaded = false
             )
         )
@@ -111,11 +117,13 @@ class LanguageDetectorBuilderTest {
 
             assertThat(builder.languages).isEqualTo(expectedLanguages)
             assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+            assertThat(builder.withoutQuadriAndFivegram).isFalse
             assertThat(builder.isEveryLanguageModelPreloaded).isFalse
             assertThat(builder.build()).isEqualTo(
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.0,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -125,6 +133,7 @@ class LanguageDetectorBuilderTest {
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.2,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -145,11 +154,13 @@ class LanguageDetectorBuilderTest {
 
             assertThat(builder.languages).isEqualTo(expectedLanguages)
             assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+            assertThat(builder.withoutQuadriAndFivegram).isFalse
             assertThat(builder.isEveryLanguageModelPreloaded).isFalse
             assertThat(builder.build()).isEqualTo(
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.0,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -159,6 +170,7 @@ class LanguageDetectorBuilderTest {
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.2,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -178,11 +190,13 @@ class LanguageDetectorBuilderTest {
 
             assertThat(builder.languages).isEqualTo(expectedLanguages)
             assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+            assertThat(builder.withoutQuadriAndFivegram).isFalse
             assertThat(builder.isEveryLanguageModelPreloaded).isFalse
             assertThat(builder.build()).isEqualTo(
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.0,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -192,6 +206,7 @@ class LanguageDetectorBuilderTest {
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.2,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -200,6 +215,7 @@ class LanguageDetectorBuilderTest {
                 LanguageDetector(
                     expectedLanguages.toMutableSet(),
                     minimumRelativeDistance = 0.2,
+                    withoutQuadriAndFivegram = false,
                     isEveryLanguageModelPreloaded = false
                 )
             )
@@ -224,5 +240,57 @@ class LanguageDetectorBuilderTest {
                 LanguageDetectorBuilder.fromAllLanguages().withMinimumRelativeDistance(1.7)
             }.withMessage(errorMessage)
         }
+    }
+
+    @Test
+    fun `assert that LanguageDetector can be built with preloaded models`() {
+        val builder = LanguageDetectorBuilder.fromLanguages(Language.GERMAN, Language.ENGLISH)
+            .withPreloadedLanguageModels()
+        val expectedLanguages = listOf(Language.GERMAN, Language.ENGLISH)
+
+        assertThat(builder.languages).isEqualTo(expectedLanguages)
+        assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+        assertThat(builder.withoutQuadriAndFivegram).isFalse
+        assertThat(builder.isEveryLanguageModelPreloaded).isTrue
+        assertThat(builder.build()).isEqualTo(
+            LanguageDetector(
+                expectedLanguages.toMutableSet(),
+                minimumRelativeDistance = 0.0,
+                withoutQuadriAndFivegram = false,
+                isEveryLanguageModelPreloaded = true
+            )
+        )
+    }
+
+    @Test
+    fun `assert that LanguageDetector can be built without quadrigram and fivegram models`() {
+        val builder = LanguageDetectorBuilder.fromLanguages(Language.GERMAN, Language.ENGLISH)
+            .withoutQuadrigramAndFivegramModels()
+        val expectedLanguages = listOf(Language.GERMAN, Language.ENGLISH)
+
+        assertThat(builder.languages).isEqualTo(expectedLanguages)
+        assertThat(builder.minimumRelativeDistance).isEqualTo(0.0)
+        assertThat(builder.withoutQuadriAndFivegram).isTrue
+        assertThat(builder.isEveryLanguageModelPreloaded).isFalse
+        assertThat(builder.build()).isEqualTo(
+            LanguageDetector(
+                expectedLanguages.toMutableSet(),
+                minimumRelativeDistance = 0.0,
+                withoutQuadriAndFivegram = true,
+                isEveryLanguageModelPreloaded = false
+            )
+        )
+
+        builder.withPreloadedLanguageModels()
+        assertThat(builder.withoutQuadriAndFivegram).isTrue
+        assertThat(builder.isEveryLanguageModelPreloaded).isTrue
+        assertThat(builder.build()).isEqualTo(
+            LanguageDetector(
+                expectedLanguages.toMutableSet(),
+                minimumRelativeDistance = 0.0,
+                withoutQuadriAndFivegram = true,
+                isEveryLanguageModelPreloaded = true
+            )
+        )
     }
 }

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -235,12 +235,14 @@ class LanguageDetectorTest {
     private var detectorForEnglishAndGerman = LanguageDetector(
         languages = mutableSetOf(ENGLISH, GERMAN),
         minimumRelativeDistance = 0.0,
+        withoutQuadriAndFivegram = false,
         isEveryLanguageModelPreloaded = false
     )
 
     private val detectorForAllLanguages = LanguageDetector(
         languages = Language.all().toMutableSet(),
         minimumRelativeDistance = 0.0,
+        withoutQuadriAndFivegram = false,
         isEveryLanguageModelPreloaded = false
     )
 
@@ -947,16 +949,60 @@ class LanguageDetectorTest {
     fun `assert that language models can be properly unloaded`() {
         removeLanguageModelsFromDetector()
 
+        assertThat(LanguageDetector.unigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.bigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.trigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.quadrigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.fivegramLanguageModels).isEmpty()
+
         val detector = LanguageDetectorBuilder
             .fromLanguages(ENGLISH, GERMAN)
             .withPreloadedLanguageModels()
             .build()
+
+        assertThat(LanguageDetector.unigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.bigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.trigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.quadrigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.fivegramLanguageModels).isNotEmpty
 
         detector.unloadLanguageModels()
 
         assertThat(LanguageDetector.unigramLanguageModels).isEmpty()
         assertThat(LanguageDetector.bigramLanguageModels).isEmpty()
         assertThat(LanguageDetector.trigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.quadrigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.fivegramLanguageModels).isEmpty()
+    }
+
+    @Test
+    fun `assert that loading of quadrigram and fivegram models can be disabled`() {
+        removeLanguageModelsFromDetector()
+
+        assertThat(LanguageDetector.unigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.bigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.trigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.quadrigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.fivegramLanguageModels).isEmpty()
+
+        val detector = LanguageDetectorBuilder
+            .fromLanguages(ENGLISH, GERMAN)
+            .withoutQuadrigramAndFivegramModels()
+            .withPreloadedLanguageModels()
+            .build()
+
+        assertThat(LanguageDetector.unigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.bigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.trigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.quadrigramLanguageModels).isEmpty()
+        assertThat(LanguageDetector.fivegramLanguageModels).isEmpty()
+
+        // Detection of short text should not trigger loading quadrigram and fivegram models
+        detector.detectLanguageOf("a very short sentence")
+
+        assertThat(LanguageDetector.unigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.bigramLanguageModels).isNotEmpty
+        assertThat(LanguageDetector.trigramLanguageModels).isNotEmpty
         assertThat(LanguageDetector.quadrigramLanguageModels).isEmpty()
         assertThat(LanguageDetector.fivegramLanguageModels).isEmpty()
     }


### PR DESCRIPTION
Relates to #101

Adds the function `LanguageDetectorBuilder.withoutQuadrigramAndFivegramModels()` which disables loading of quadrigram and fivegram models. Quadrigram and fivegram models take up the majority of memory during runtime; if my measurements are correct, all language models preloaded require ~1783 MB, whereas only unigram, bigram and trigram models require ~110 MB. However, for larger texts `LanguageDetector` does not [actually use them](https://github.com/pemistahl/lingua/blob/f24155bae4fe37d650c0fb92c919d9ef6395d1c2/src/main/kotlin/com/github/pemistahl/lingua/api/LanguageDetector.kt#L127).
Therefore, for use cases where it is known beforehand that most or all texts will be longer than ~120 chars, it should be relatively safe to disable of loading quadrigram and fivegram models.

Any feedback, especially regarding the builder function name and documentation, is appreciated.