### PR TITLE
Fix Java module descriptor configuration

### DIFF
--- a/src/main/java-9/module-info.java
+++ b/src/main/java-9/module-info.java
@@ -1,0 +1,15 @@
+module com.github.pemistahl.lingua {
+    exports com.github.pemistahl.lingua.api;
+
+    requires kotlin.stdlib;
+
+    requires it.unimi.dsi.fastutil;
+    requires okio;
+
+    // Moshi accesses JSON serializer using reflection; must open the package
+    // TODO: Once new Moshi version has module names, change it to `opens ... to com.squareup.moshi`
+    //       and comment in the `requires` declarations below
+    opens com.github.pemistahl.lingua.internal;
+    // requires com.squareup.moshi;
+    // requires com.squareup.moshi.kotlin;
+}

--- a/src/main/resources/META-INF/versions/9/module-info.java
+++ b/src/main/resources/META-INF/versions/9/module-info.java
@@ -1,3 +1,0 @@
-module com.github.pemistahl.lingua {
-    exports com.github.pemistahl.lingua.api;
-}

--- a/src/testModular/java/module-info.java
+++ b/src/testModular/java/module-info.java
@@ -1,0 +1,6 @@
+// Open complete module for reflection to allow JUnit to access the packages
+open module test {
+    requires com.github.pemistahl.lingua;
+
+    requires org.junit.jupiter.api;
+}

--- a/src/testModular/java/test/LinguaTest.java
+++ b/src/testModular/java/test/LinguaTest.java
@@ -1,0 +1,21 @@
+package test;
+
+import com.github.pemistahl.lingua.api.*;
+import org.junit.jupiter.api.Test;
+
+import static com.github.pemistahl.lingua.api.Language.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests basic Lingua functionality. The main purpose of this test is to verify that the
+ * packages can be accessed from a different module and that Lingua specifies all required
+ * modules and can be used successfully.
+ */
+class LinguaTest {
+    @Test
+    void test() {
+        LanguageDetector detector = LanguageDetectorBuilder.fromLanguages(ENGLISH, FRENCH, GERMAN, SPANISH).build();
+        Language detectedLanguage = detector.detectLanguageOf("languages are awesome");
+        assertEquals(ENGLISH, detectedLanguage);
+    }
+}


### PR DESCRIPTION
Resolves hopefully #120

The workaround needed for the moditect-gradle-plugin issue is a bit brittle, but it seems to work for the current Lingua setup.
Only the regular JAR is a Multi-Release JAR with module descriptor; the created `-with-dependencies.jar` is not a proper Multi-Release JAR, but that probably does not matter because I think you would normally not use JARs with dependencies as modules.

Also adds a test to verify that the modular JAR can be used by using the incubating Gradle [Test Suite feature](https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html#jvm_test_suite_plugin).

One issue with the moditect-gradle-plugin is that it does not seem to detect incorrect configuration of the `module-info.java` file, such as missing `requires` or `exports` of a non-existent package (though the test suite added by this PR would hopefully catch that). An alternative might be to perform regular compilation of the `module-info.java` file, similar to what is [described in this StackOverflow question](https://stackoverflow.com/questions/47657755/building-a-kotlin-java-9-project-with-gradle) but that would require some adjustments to create a Multi-Release JAR.