### PR TITLE
Allow `щ` for Ukrainian language

### DIFF
--- a/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
+++ b/src/main/kotlin/com/github/pemistahl/lingua/internal/Constant.kt
@@ -96,7 +96,8 @@ internal object Constant {
         "Ôô" to enumSetOf(FRENCH, PORTUGUESE, SLOVAK, VIETNAMESE),
 
         "ЁёЫыЭэ" to enumSetOf(BELARUSIAN, KAZAKH, MONGOLIAN, RUSSIAN),
-        "ЩщЪъ" to enumSetOf(BULGARIAN, KAZAKH, MONGOLIAN, RUSSIAN),
+        "Щщ" to enumSetOf(BULGARIAN, KAZAKH, MONGOLIAN, RUSSIAN, UKRAINIAN),
+        "Ъъ" to enumSetOf(BULGARIAN, KAZAKH, MONGOLIAN, RUSSIAN),
         "Òò" to enumSetOf(CATALAN, ITALIAN, VIETNAMESE, YORUBA),
         "Ææ" to enumSetOf(BOKMAL, DANISH, ICELANDIC, NYNORSK),
         "Åå" to enumSetOf(BOKMAL, DANISH, NYNORSK, SWEDISH),

--- a/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
+++ b/src/test/kotlin/com/github/pemistahl/lingua/api/LanguageDetectorTest.kt
@@ -577,7 +577,7 @@ class LanguageDetectorTest {
         ),
         arguments(
             "плаваща",
-            listOf(BULGARIAN, KAZAKH, MONGOLIAN, RUSSIAN)
+            listOf(BULGARIAN, KAZAKH, MONGOLIAN, RUSSIAN, UKRAINIAN)
         ),
         arguments(
             "довършат",


### PR DESCRIPTION
In this PR, I fix a letter-based rule that prevented Ukrainian language to be detected if the letter `щ` is used. This letter is, in fact, part of the Ukrainian alphabet.